### PR TITLE
Added relative density calc to Roberston interpret function

### DIFF
--- a/geolib_plus/robertson_cpt_interpretation/robertson_cpt_interpretation.py
+++ b/geolib_plus/robertson_cpt_interpretation/robertson_cpt_interpretation.py
@@ -60,6 +60,7 @@ class RobertsonCptInterpretation(AbstractInterpretationMethod, BaseModel):
     unitweightmethod: UnitWeightMethod = UnitWeightMethod.ROBERTSON
     ocrmethod: OCRMethod = OCRMethod.ROBERTSON
     shearwavevelocitymethod: ShearWaveVelocityMethod = ShearWaveVelocityMethod.ROBERTSON
+    relativedensitymethod: RelativeDensityMethod = RelativeDensityMethod.BALDI
     data: AbstractCPT = None
     gamma: Iterable = []
     polygons: Iterable = []
@@ -142,6 +143,9 @@ class RobertsonCptInterpretation(AbstractInterpretationMethod, BaseModel):
 
         # compute state parameter
         self.state_parameter_calc()
+
+        # compute relative
+        self.relative_density_calc(method=self.relativedensitymethod)
 
         # filter values
         # lithologies = [""]


### PR DESCRIPTION
When you utilized the Robertson CPT Interpretation, the relative density calculation function was not executed. With these changes, the relative density calculation function will now be executed using the default values whenever a Robertson CPT Interpretation is performed.