### PR TITLE
Add secondary encoding (cp1252) to GEF reader

### DIFF
--- a/geolib_plus/gef_cpt/gef_file_reader.py
+++ b/geolib_plus/gef_cpt/gef_file_reader.py
@@ -170,7 +170,11 @@ class GefFileReader(CptReader):
         inputs from gef file.
         """
         # read gef file
-        with open(gef_file, "r") as f:
+        try:
+            with open(gef_file, "r") as f:
+                data = f.readlines()
+        except UnicodeDecodeError:
+            with open(gef_file, "r", encoding='cp1252') as f:
             data = f.readlines()
 
         # search NAP

--- a/geolib_plus/gef_cpt/gef_file_reader.py
+++ b/geolib_plus/gef_cpt/gef_file_reader.py
@@ -175,7 +175,7 @@ class GefFileReader(CptReader):
                 data = f.readlines()
         except UnicodeDecodeError:
             with open(gef_file, "r", encoding='cp1252') as f:
-            data = f.readlines()
+                data = f.readlines()
 
         # search NAP
         idx_nap = GefFileReader.get_line_index_from_data_starts_with(


### PR DESCRIPTION
If the GEF file cannot be read with the default encoding (UTF8) it will fall back onto the cp1252 encoding. This helps to accept GEF files as commonly produced by dutch suppliers.

Fix to solve this issue: https://github.com/Deltares/GEOLib-Plus/issues/6#issuecomment-2385261684