### PR TITLE
fixed the __correct_for_negatives function to work properly. It used …

### DIFF
--- a/geolib_plus/cpt_base_model.py
+++ b/geolib_plus/cpt_base_model.py
@@ -299,7 +299,7 @@ class AbstractCPT(BaseModel):
         have to be zero.
         """
         if data is not None:
-            if data.size != 0 and not data.ndim:
+            if data.size != 0:
                 data[data < 0] = 0
             return data
 


### PR DESCRIPTION
The negative values were not properly replaced with zero for the friction, tip and friciton_nbr; in the __correct_for_negatives function in the pre_process steps... I checked the tests and 3 remain failing as it was before the changes....

In the original code, the condition is never True, and thus data never gets fixed.
```
if data.size != 0 and not data.ndim:
     data[data < 0] = 0
```
**Why the condition is never True?**

data.ndim returns the number of dimensions (or axes) of a NumPy array

If data is:
A scalar (single number) → data.ndim == 0
A 1D array (like a list) → data.ndim == 1
A 2D array (like a table) → data.ndim == 2, and so on

Then, the condition:
if data.size != 0 and not data.ndim:
--> is only true if data.ndim == 0 (meaning data is a single scalar value).

**What Happens?**
If data is a scalar
(e.g., np.array(5)):

not data.ndim → True, so the function executes data[data < 0] = 0.
✅ Works fine.
If data is a 1D or 2D array (which it usually is in real use cases):

not data.ndim → False, because data.ndim is 1 or greater.
The condition fails, so negative values are NOT changed. ❌